### PR TITLE
Added a call to the currently unused 'signature' string variable.

### DIFF
--- a/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
+++ b/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
@@ -57,7 +57,7 @@ namespace StorageRestApiAuth
             // This is the actual header that will be added to the list of request headers.
             // You can stop the code here and look at the value of 'authHV' before it is returned.
             AuthenticationHeaderValue authHV = new AuthenticationHeaderValue("SharedKey",
-                storageAccountName + ":" + Convert.ToBase64String(SHA256.ComputeHash(SignatureBytes)));
+                storageAccountName + ":" + signature;
             return authHV;
         }
 


### PR DESCRIPTION
The existing code was not using the 'signature' string variable on line 55 of the AzureStorageAuthenticationHelper class (see below).  I updated the code to use the intended variable.

<img width="394" alt="ss" src="https://user-images.githubusercontent.com/38665906/52154861-6fb14c00-2645-11e9-961f-a0cd990e179f.png">
