### PR TITLE
Fix incorrect lowercasing in GetCanonicalizedResource

### DIFF
--- a/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
+++ b/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net.Http;

--- a/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
+++ b/StorageRestApiAuth/AzureStorageAuthenticationHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net.Http;
@@ -57,7 +57,7 @@ namespace StorageRestApiAuth
             // This is the actual header that will be added to the list of request headers.
             // You can stop the code here and look at the value of 'authHV' before it is returned.
             AuthenticationHeaderValue authHV = new AuthenticationHeaderValue("SharedKey",
-                storageAccountName + ":" + Convert.ToBase64String(SHA256.ComputeHash(SignatureBytes)));
+                storageAccountName + ":" + signature);
             return authHV;
         }
 
@@ -120,10 +120,10 @@ namespace StorageRestApiAuth
 
             foreach (var item in values.AllKeys.OrderBy(k => k))
             {
-                sb.Append('\n').Append(item).Append(':').Append(values[item]);
+                sb.Append('\n').Append(item.ToLower()).Append(':').Append(values[item]);
             }
 
-            return sb.ToString().ToLower();
+            return sb.ToString();
 
         }
     }


### PR DESCRIPTION
There is a bug in the `GetCanonicalizedResource()` method. It is lowercasing the entire CanonicalizedResource string where it should only be lowercasing the names of the query parameters (c.f. https://github.com/MicrosoftDocs/azure-docs/issues/32933 and https://github.com/MicrosoftDocs/azure-docs/commit/d24bd4b7034523ca910cc5cee56de5a67f4419fb).
As a result, this helper can produce tokens that don't work if the target URL has capital letters in the non-query portion of the URL or any of the parameter values.

The solution is to apply the same change made in https://github.com/MicrosoftDocs/azure-docs/commit/d24bd4b7034523ca910cc5cee56de5a67f4419fb and only lowercase the parameter names, not the whole string.


Additionally, there is an unused `signature` variable in `GetAuthorizationHeader()` - the signature is generated once on line 55 and again on line 60, resulting in duplicated code and an unused variable. I have remedied this by making use of the `signature` variable on line 60.